### PR TITLE
[VB-170] fixed safeAreaLayoutGuide.bottomAnchor

### DIFF
--- a/VolleyBolley/Common/UI/Buttons/Green/GreenButton.swift
+++ b/VolleyBolley/Common/UI/Buttons/Green/GreenButton.swift
@@ -58,9 +58,7 @@ final class GreenButton: UIButton {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    required init?(coder: NSCoder) { nil }
 
     override func layoutSubviews() {
         super.layoutSubviews()
@@ -108,6 +106,8 @@ final class GreenButton: UIButton {
         attributes.font = font
         attributes.foregroundColor = style.titleColor
         config.attributedTitle = AttributedString(title(for: state) ?? "", attributes: attributes)
+		config.titleLineBreakMode = .byTruncatingTail
+		titleLabel?.numberOfLines = 1
     }
 
     func configureImage(style: GreenButtonStyle, state: UIControl.State, config: inout UIButton.Configuration) {

--- a/VolleyBolley/Modules/About/View/AboutViewController.swift
+++ b/VolleyBolley/Modules/About/View/AboutViewController.swift
@@ -32,7 +32,7 @@ final class AboutViewController: BaseViewController {
 		static let tableEstimatedRowHeight: CGFloat = 44
 
 		static let versionFontSize: CGFloat = 14
-		static let versionBottomInset: CGFloat = -60
+		static let versionBottomInset: CGFloat = -12
 	}
 
 	// MARK: - Private Properties

--- a/VolleyBolley/Modules/FAQ/View/FAQViewController.swift
+++ b/VolleyBolley/Modules/FAQ/View/FAQViewController.swift
@@ -96,7 +96,7 @@ private extension FAQViewController {
 			background.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: contentInset),
 			background.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: contentInset),
 			background.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -contentInset),
-			background.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -55),
+			background.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -contentInset),
 
 			buttonBack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: mainSpacing),
 			buttonBack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: mainSpacing),

--- a/VolleyBolley/Modules/Home/View/HomeViewController.swift
+++ b/VolleyBolley/Modules/Home/View/HomeViewController.swift
@@ -25,7 +25,7 @@ final class HomeViewController: BaseViewController, HomeViewProtocol {
 		static let backgroundImageViewWidth: CGFloat = 302
 		static let backgroundImageViewHeight: CGFloat = 245
 		static let spacing: CGFloat = 7
-		static let vStackTopInset: CGFloat = 224
+		static let vStackTopInset: CGFloat = 219
 	}
 
 	private let scrollView: UIScrollView = {
@@ -206,7 +206,7 @@ final class HomeViewController: BaseViewController, HomeViewProtocol {
 				constant: -Constants.spacing
 			),
 			vStackView.bottomAnchor.constraint(
-				equalTo: contentView.bottomAnchor,
+				lessThanOrEqualTo: contentView.bottomAnchor,
 				constant: -16
 			)
 		])

--- a/VolleyBolley/Modules/Home/View/HomeViewController.swift
+++ b/VolleyBolley/Modules/Home/View/HomeViewController.swift
@@ -9,133 +9,225 @@ import UIKit
 
 @MainActor
 protocol HomeViewProtocol: AnyObject {
-    func displayCreateNewGameButton(state: CreateNewGameButtonState)
-    func displayFindGameButton(gamesCount: Int)
+	func displayCreateNewGameButton(state: CreateNewGameButtonState)
+	func displayFindGameButton(gamesCount: Int)
 }
 
 final class HomeViewController: BaseViewController, HomeViewProtocol {
 
-    // MARK: - Private Properties
+	// MARK: - Private Properties
 
-    private let presenter: HomePresenterProtocol
-    private var createNewGameCourtId: Int?
+	private let presenter: HomePresenterProtocol
+	private var createNewGameCourtId: Int?
 
-    private enum Constants {
-        static let backgroundTop: CGFloat = 90
-        static let verticalStackSpacing: CGFloat = 8
-        static let horizontalStackSpacing: CGFloat = 8
-        static let contentInsets = UIEdgeInsets(top: 324, left: 8, bottom: 100, right: 8)
-    }
+	private enum Constants {
+		static let backgroundImageViewTopInset: CGFloat = -8
+		static let backgroundImageViewWidth: CGFloat = 302
+		static let backgroundImageViewHeight: CGFloat = 245
+		static let spacing: CGFloat = 7
+		static let vStackTopInset: CGFloat = 224
+	}
 
-    private lazy var backgroundImageView: UIImageView = {
-        let view = UIImageView()
-        view.image = UIImage.Image.homeBackground
-        view.contentMode = .topLeft
-        return view
-    }()
+	private let scrollView: UIScrollView = {
+		let view = UIScrollView()
+		view.alwaysBounceVertical = true
+		return view
+	}()
 
-    private lazy var mainStackView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [topStackView, bottomStackView])
-        view.axis = .vertical
-        view.spacing = Constants.verticalStackSpacing
-        return view
-    }()
+	private let contentView = UIView()
 
-    private lazy var topStackView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [createNewGameButton, findGameButton])
-        view.axis = .vertical
-        view.distribution = .fillEqually
-        view.spacing = Constants.verticalStackSpacing
-        return view
-    }()
+	private lazy var backgroundImageView: UIImageView = {
+		let view = UIImageView()
+		view.image = UIImage.Image.homeBackground
+		view.contentMode = .topLeft
+		return view
+	}()
 
-    private lazy var bottomStackView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [createTourneyButton, donateButton])
-        view.axis = .horizontal
-        view.spacing = Constants.horizontalStackSpacing
-        view.distribution = .fillEqually
-        return view
-    }()
+	private let backgroundImageFadeMaskLayer = CAGradientLayer()
 
-    private lazy var createNewGameButton: CreateNewGameButton = {
-        let view = CreateNewGameButton()
-        view.addAction(UIAction { [weak self] _ in
-             self?.presenter.didTapCreateNewGame()
-        }, for: .touchUpInside)
-        return view
-    }()
+	private lazy var vStackView: UIStackView = {
+		let view = UIStackView(arrangedSubviews: [
+			createNewGameButton,
+			findGameButton,
+			hStackView
+		])
+		view.axis = .vertical
+		view.spacing = Constants.spacing
+		return view
+	}()
 
-    private lazy var findGameButton: FindGameButton = {
-        let view = FindGameButton()
-        view.addAction(UIAction { [weak self] _ in
-             self?.presenter.didTapFindGame()
-        }, for: .touchUpInside)
-        return view
-    }()
+	private lazy var hStackView: UIStackView = {
+		let view = UIStackView(arrangedSubviews: [createTourneyButton, donateButton])
+		view.axis = .horizontal
+		view.spacing = Constants.spacing
+		view.distribution = .fillEqually
+		return view
+	}()
 
-    private lazy var createTourneyButton: SketchButton = {
+	private lazy var createNewGameButton: CreateNewGameButton = {
+		let view = CreateNewGameButton()
+		view.addAction(UIAction { [weak self] _ in
+			self?.presenter.didTapCreateNewGame()
+		}, for: .touchUpInside)
+		return view
+	}()
+
+	private lazy var findGameButton: FindGameButton = {
+		let view = FindGameButton()
+		view.addAction(UIAction { [weak self] _ in
+			self?.presenter.didTapFindGame()
+		}, for: .touchUpInside)
+		return view
+	}()
+
+	private lazy var createTourneyButton: SketchButton = {
 		let view = SketchButton(type: .createTourney, isSelected: true)
-        view.addAction(UIAction { [weak self] _ in
-             self?.presenter.didTapCreateTourney()
-        }, for: .touchUpInside)
-        return view
-    }()
+		view.addAction(UIAction { [weak self] _ in
+			self?.presenter.didTapCreateTourney()
+		}, for: .touchUpInside)
+		return view
+	}()
 
-    private lazy var donateButton: SketchButton = {
+	private lazy var donateButton: SketchButton = {
 		let view = SketchButton(type: .donate)
-        view.addAction(UIAction { [weak self] _ in
-            self?.presenter.didTapDonate()
-        }, for: .touchUpInside)
-        return view
-    }()
+		view.addAction(UIAction { [weak self] _ in
+			self?.presenter.didTapDonate()
+		}, for: .touchUpInside)
+		return view
+	}()
 
-    // MARK: - Initializers
+	// MARK: - Initializers
 
-    init(presenter: HomePresenterProtocol) {
-        self.presenter = presenter
-        super.init(nibName: nil, bundle: nil)
-    }
+	init(presenter: HomePresenterProtocol) {
+		self.presenter = presenter
+		super.init(nibName: nil, bundle: nil)
+	}
 
-    @available(*, unavailable)
-    required init?(coder: NSCoder) { nil }
+	@available(*, unavailable)
+	required init?(coder: NSCoder) { nil }
 
-    // MARK: - Lifecycle
+	// MARK: - Lifecycle
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+	override func viewDidLoad() {
+		super.viewDidLoad()
 
-        setupView()
-        presenter.viewDidLoad()
-    }
+		setupView()
+		presenter.viewDidLoad()
+	}
 
-    // MARK: - Public Methods
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		applyBackgroundImageFadeMask()
+	}
 
-    func displayCreateNewGameButton(state: CreateNewGameButtonState) {
-        createNewGameButton.configure(state: state)
-    }
+	// MARK: - Public Methods
 
-    func displayFindGameButton(gamesCount: Int) {
-        findGameButton.configure(with: gamesCount)
-    }
+	func displayCreateNewGameButton(state: CreateNewGameButtonState) {
+		createNewGameButton.configure(state: state)
+	}
 
-    // MARK: - Private Methods
+	func displayFindGameButton(gamesCount: Int) {
+		findGameButton.configure(with: gamesCount)
+	}
 
-    private func setupView() {
-        view.addSubviews(
-			backgroundImageView,
-			mainStackView
-		)
-        mainStackView.pinToSuperviewEdges(insets: Constants.contentInsets)
-        setupConstraintsBackgroundImageView()
-    }
+	// MARK: - Private Methods
 
-    // MARK: - Constraints
+	private func applyBackgroundImageFadeMask() {
+		let fadeHeight: CGFloat = 80
 
-    private func setupConstraintsBackgroundImageView() {
-        NSLayoutConstraint.activate([
-            backgroundImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.backgroundTop),
-            backgroundImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            backgroundImageView.widthAnchor.constraint(equalTo: view.widthAnchor)
-        ])
-    }
+		let imageHeight = backgroundImageView.bounds.height
+		guard imageHeight > 0 else { return }
+
+		backgroundImageFadeMaskLayer.frame = backgroundImageView.bounds
+
+		let startFadeLocation = max((imageHeight - fadeHeight) / imageHeight, 0)
+
+		backgroundImageFadeMaskLayer.colors = [
+			UIColor.white.cgColor,
+			UIColor.white.cgColor,
+			UIColor.clear.cgColor
+		]
+
+		backgroundImageFadeMaskLayer.locations = [
+			0.0,
+			NSNumber(value: Float(startFadeLocation)),
+			1.0
+		]
+
+		backgroundImageView.layer.mask = backgroundImageFadeMaskLayer
+	}
+
+	private func setupView() {
+		view.addSubviews(backgroundImageView, scrollView)
+		scrollView.addSubviews(contentView)
+		contentView.addSubviews(vStackView)
+
+		setupConstraintsScrollView()
+		setupConstraintsContentView()
+		setupConstraintsVStackView()
+		setupConstraintsBackgroundImageView()
+		setupConstraintsSketchButtons()
+	}
+
+	// MARK: - Constraints
+
+	private func setupConstraintsScrollView() {
+		NSLayoutConstraint.activate([
+			scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+			scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+			scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 36)
+		])
+	}
+
+	private func setupConstraintsContentView() {
+		NSLayoutConstraint.activate([
+			contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+			contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+			contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+			contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+
+			contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+		])
+	}
+
+	private func setupConstraintsVStackView() {
+		NSLayoutConstraint.activate([
+			vStackView.topAnchor.constraint(
+				equalTo: contentView.topAnchor,
+				constant: Constants.vStackTopInset
+			),
+			vStackView.leadingAnchor.constraint(
+				equalTo: contentView.leadingAnchor,
+				constant: Constants.spacing
+			),
+			vStackView.trailingAnchor.constraint(
+				equalTo: contentView.trailingAnchor,
+				constant: -Constants.spacing
+			),
+			vStackView.bottomAnchor.constraint(
+				equalTo: contentView.bottomAnchor,
+				constant: -16
+			)
+		])
+	}
+
+	private func setupConstraintsBackgroundImageView() {
+		NSLayoutConstraint.activate([
+			backgroundImageView.topAnchor.constraint(
+				equalTo: view.safeAreaLayoutGuide.topAnchor,
+				constant: Constants.backgroundImageViewTopInset
+			),
+			backgroundImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+			backgroundImageView.heightAnchor.constraint(equalToConstant: Constants.backgroundImageViewHeight),
+			backgroundImageView.widthAnchor.constraint(equalToConstant: Constants.backgroundImageViewWidth)
+		])
+	}
+
+	private func setupConstraintsSketchButtons() {
+		NSLayoutConstraint.activate([
+			createTourneyButton.heightAnchor.constraint(equalTo: createTourneyButton.widthAnchor),
+			donateButton.heightAnchor.constraint(equalTo: donateButton.widthAnchor)
+		])
+	}
 }

--- a/VolleyBolley/Modules/Main/BaseViewController.swift
+++ b/VolleyBolley/Modules/Main/BaseViewController.swift
@@ -26,6 +26,8 @@ class BaseViewController: UIViewController {
 		return NavBarAssembly.createModule(with: self)
 	}()
 
+	private var safeAreaTopInset: CGFloat = .zero
+
 	// MARK: - Private Properties
 
 	private let notificationManager = NotificationManager.shared
@@ -46,11 +48,7 @@ class BaseViewController: UIViewController {
 
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
-		// dynamic island fixes
-		let topInset = view.safeAreaInsets.top
-		let topInsets: CGFloat = topInset >= 106 ? 44 : 58
-		additionalSafeAreaInsets.top = topInsets
-
+		setupAdditionalSafeAreaInset()
 		view.bringSubviewToFront(navBar)
 	}
 
@@ -63,6 +61,15 @@ class BaseViewController: UIViewController {
 // MARK: - Private Methods
 
 private extension BaseViewController {
+
+	/// custom navBar + dynamic island workaround
+	func setupAdditionalSafeAreaInset() {
+		let navBarFrameInView = navBar.convert(navBar.bounds, to: view)
+		let safeTop = view.safeAreaInsets.top
+		let extraTopInset = max(0, navBarFrameInView.maxY - safeTop)
+		safeAreaTopInset = max(safeAreaTopInset, extraTopInset)
+		additionalSafeAreaInsets.top = safeAreaTopInset
+	}
 
 	func setupCustomNavigationBar() {
 		view.addSubviews(navBar)

--- a/VolleyBolley/Modules/Main/BaseViewController.swift
+++ b/VolleyBolley/Modules/Main/BaseViewController.swift
@@ -46,7 +46,11 @@ class BaseViewController: UIViewController {
 
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
-		additionalSafeAreaInsets.top = 44
+		// dynamic island fixes
+		let topInset = view.safeAreaInsets.top
+		let topInsets: CGFloat = topInset >= 106 ? 44 : 58
+		additionalSafeAreaInsets.top = topInsets
+
 		view.bringSubviewToFront(navBar)
 	}
 

--- a/VolleyBolley/Modules/Main/TabBar/MainTabBarController.swift
+++ b/VolleyBolley/Modules/Main/TabBar/MainTabBarController.swift
@@ -43,6 +43,11 @@ final class MainTabBarController: UIViewController {
 		setupNotificationService()
 	}
 
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		additionalSafeAreaInsets.bottom = 48
+	}
+
 	func setViewControllers(_ viewControllers: [TabBarItem: UIViewController]) {
 		for child in children {
 			child.willMove(toParent: nil)

--- a/VolleyBolley/Modules/Map/MapViewController.swift
+++ b/VolleyBolley/Modules/Map/MapViewController.swift
@@ -227,7 +227,6 @@ private extension MapViewController {
             bottomView,
             backButton
 		)
-		let popupBottonInset: CGFloat = -55
 		let mainInset: CGFloat = 8
 
 		NSLayoutConstraint.activate([
@@ -245,7 +244,7 @@ private extension MapViewController {
 
 			bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: mainInset),
 			bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -mainInset),
-			bottomView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: popupBottonInset),
+			bottomView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -mainInset),
 			bottomView.heightAnchor.constraint(equalToConstant: 136)
 		])
 
@@ -253,7 +252,7 @@ private extension MapViewController {
 		popupView.isHidden = true
 		popupBottomConstraint = popupView.bottomAnchor.constraint(
 			equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-			constant: popupBottonInset
+			constant: -mainInset
 		)
 		if let popupBottomConstraint {
 			NSLayoutConstraint.activate([popupBottomConstraint])

--- a/VolleyBolley/Modules/Map/MapViewController.swift
+++ b/VolleyBolley/Modules/Map/MapViewController.swift
@@ -228,13 +228,14 @@ private extension MapViewController {
             backButton
 		)
 		let popupBottonInset: CGFloat = -55
+		let mainInset: CGFloat = 8
 
 		NSLayoutConstraint.activate([
-			segmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+			segmentedControl.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: mainInset),
 			segmentedControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
 			segmentedControl.widthAnchor.constraint(equalToConstant: 200),
 
-			backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+			backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: mainInset),
             backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
 
 			mapView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -242,8 +243,8 @@ private extension MapViewController {
 			mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 			mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-			bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-			bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+			bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: mainInset),
+			bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -mainInset),
 			bottomView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: popupBottonInset),
 			bottomView.heightAnchor.constraint(equalToConstant: 136)
 		])
@@ -258,8 +259,8 @@ private extension MapViewController {
 			NSLayoutConstraint.activate([popupBottomConstraint])
 		}
 		NSLayoutConstraint.activate([
-			popupView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
-			popupView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+			popupView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: mainInset),
+			popupView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -mainInset),
 			popupView.heightAnchor.constraint(equalToConstant: 472)
 		])
 	}

--- a/VolleyBolley/Modules/NewGameOrTourney/View/NewGameOrTourneyController.swift
+++ b/VolleyBolley/Modules/NewGameOrTourney/View/NewGameOrTourneyController.swift
@@ -32,8 +32,6 @@ final class NewGameOrTourneyViewController: BaseViewController, NewGameOrTourney
 		static let backButtonTopInset: CGFloat = 20
 		static let backButtonSize: CGFloat = 24
 
-		static let bottomInset: CGFloat = 63
-
 		static let titleFontSize: CGFloat = 24
 	}
 
@@ -106,7 +104,6 @@ final class NewGameOrTourneyViewController: BaseViewController, NewGameOrTourney
 
 	override func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
-		// ALWAYS raise the customAlertView above all other subviews
 		view.bringSubviewToFront(customAlertView)
 	}
 
@@ -198,7 +195,7 @@ private extension NewGameOrTourneyViewController {
 			),
 			nextButton.bottomAnchor.constraint(
 				equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-				constant: -Constants.bottomInset
+				constant: -Constants.padding
 			)
 		])
 	}

--- a/VolleyBolley/Modules/Profile/View/ProfileViewController.swift
+++ b/VolleyBolley/Modules/Profile/View/ProfileViewController.swift
@@ -130,7 +130,7 @@ private extension ProfileViewController {
             tableView.heightAnchor.constraint(equalToConstant: 400),
 
             deleteButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 28),
-			deleteButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -60)
+			deleteButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
         ])
     }
 }


### PR DESCRIPTION
**Что сделано:**

1. поправил safeAreaLayoutGuide.bottomAnchor (**внимание**, хардкод) и убрал лишние магические числа
2. MapViewController: исправил отступы у всплывашек на карте, они там неправильные были немного
3. перенес код из ПР Николая для HomeViewController, но он все равно кривой и на 16е полезли проблемы, пофиксил +/-
4. сделал обрезку текста у title для GreenButton как обсудили
5. BaseViewController - пришлось вносить правки для navbar, почему-то поехало на 16е, хотя в предыдущем пр по исправлению navbar все ок было, **более менее выровнял верстку для 17 / 17pro / 16e, других эмуляторов у меня нет сейчас, хорошо бы и другие размеры проверить**. Решение спорное и костыльное, мне не нравится, открыт к предложениям

```
		// dynamic island fixes
		let topInset = view.safeAreaInsets.top
		let topInsets: CGFloat = topInset >= 106 ? 44 : 58
		additionalSafeAreaInsets.top = topInsets
```

**UPD:** нашел решение без хардкода https://github.com/o1isrta/VolleyBolleyIOS/pull/171/commits/bc1cb0888c08b898f6d817580a2c17dbf43c3088

Если есть возможность проверить на разных эмуляторах, то было бы круто, я систему в декабре обновил и у меня только такие сейчас есть

P.S. **возможно, для additionalSafeAreaInsets.bottom тоже можно обойтись без хардкода** таким же образом, только тут пока роли особо не играет